### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "browserify",
     "server"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Lapple/browserverify.git"
+  },
   "license": "MIT",
   "dependencies": {
     "express": "~3.4.4",


### PR DESCRIPTION
Should fix the url not showing up in npm: https://www.npmjs.com/package/browserverify
